### PR TITLE
💄UI: Glassmorphic Tab 배경 블러 처리

### DIFF
--- a/app/src/main/java/com/busymodernpeople/galapagos/ui/component/BlurredComposeView.kt
+++ b/app/src/main/java/com/busymodernpeople/galapagos/ui/component/BlurredComposeView.kt
@@ -1,0 +1,68 @@
+package com.busymodernpeople.galapagos.ui.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.busymodernpeople.galapagos.R
+import com.busymodernpeople.galapagos.ui.component.capture.Capturable
+import com.busymodernpeople.galapagos.ui.component.capture.rememberCaptureController
+import com.busymodernpeople.galapagos.ui.theme.GalapagosTheme
+import kotlinx.coroutines.delay
+
+@Composable
+fun BlurredComposeView(content: @Composable () -> Unit) {
+    val captureController = rememberCaptureController()
+    var background: ImageBitmap? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            captureController.capture()
+            delay(30)
+        }
+    }
+
+    Box {
+        Capturable(
+            controller = captureController,
+            onCaptured = { bitmap, _ ->
+                bitmap?.let {
+                    background = bitmap
+                }
+            }
+        ) {
+            content()
+        }
+
+        background?.let {
+            Image(
+                modifier = Modifier.blur(50.dp),
+                bitmap = it,
+                contentDescription = null
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewBlurComposeView() {
+    GalapagosTheme {
+        Box(contentAlignment = Alignment.Center) {
+            BlurredComposeView {
+                Image(
+                    modifier = Modifier.fillMaxSize(),
+                    painter = painterResource(id = R.drawable.crab),
+                    contentDescription = null
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/busymodernpeople/galapagos/ui/component/Tab.kt
+++ b/app/src/main/java/com/busymodernpeople/galapagos/ui/component/Tab.kt
@@ -4,8 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -218,24 +217,22 @@ fun GlassmorphicTab(
     )
 
     Box {
-        Surface(
-            modifier = modifier
-                .width(width)
-                .height(height)
-                .border(
-                    width = 1.dp,
-                    color = BgGray5,
-                    shape = CircleShape
-                )
-                .blur(
-                    radius = 10.dp,
-                    edgeTreatment = BlurredEdgeTreatment(CircleShape)
-                ),
-            shape = CircleShape,
-            color = Color.White.copy(alpha = 0.4f),
-            elevation = 12.dp
-        ) {
-            Spacer(modifier = Modifier.fillMaxSize())
+        BlurredComposeView {
+            Surface(
+                modifier = modifier
+                    .width(width)
+                    .height(height)
+                    .border(
+                        width = 1.dp,
+                        color = BgGray5,
+                        shape = CircleShape
+                    ),
+                color = Color.Transparent,
+                shape = CircleShape,
+                elevation = 12.dp
+            ) {
+                Spacer(modifier = Modifier.fillMaxSize())
+            }
         }
 
         Box(

--- a/app/src/main/java/com/busymodernpeople/galapagos/ui/component/capture/Capturable.kt
+++ b/app/src/main/java/com/busymodernpeople/galapagos/ui/component/capture/Capturable.kt
@@ -1,0 +1,172 @@
+package com.busymodernpeople.galapagos.ui.component.capture
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import android.view.View
+import android.view.Window
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.doOnLayout
+import androidx.core.view.drawToBitmap
+import kotlinx.coroutines.flow.*
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * A composable with [content] which supports to capture [ImageBitmap] from a [content].
+ *
+ * Example usage:
+ *
+ * ```
+ *  val captureController = rememberCaptureController()
+ *  Capturable(
+ *      controller = captureController,
+ *      onCaptured = { bitmap, error ->
+ *          // Do something with [bitmap]
+ *          // Handle [error] if required
+ *      }
+ *  ) {
+ *      // Composable content
+ *  }
+ *
+ *  Button(onClick = {
+ *      // Capture content
+ *      captureController.capture()
+ *  }) { ... }
+ * ```
+ *
+ * @param controller A [CaptureController] which gives control to capture the [content].
+ * @param modifier The [Modifier] to be applied to the layout.
+ * @param onCaptured The callback which gives back [ImageBitmap] after composable is captured.
+ * If any error is occurred while capturing bitmap, [Throwable] is provided.
+ * @param content [Composable] content to be captured.
+ */
+@Composable
+fun Capturable(
+    controller: CaptureController,
+    modifier: Modifier = Modifier,
+    onCaptured: (ImageBitmap?, Throwable?) -> Unit,
+    content: @Composable () -> Unit
+) {
+    val context = LocalContext.current
+    AndroidView(
+        factory = { ComposeView(it).applyCapturability(controller, onCaptured, content, context) },
+        modifier = modifier
+    )
+}
+
+/**
+ * Sets the [content] in [ComposeView] and handles the capture of a [content].
+ */
+private inline fun ComposeView.applyCapturability(
+    controller: CaptureController,
+    noinline onCaptured: (ImageBitmap?, Throwable?) -> Unit,
+    crossinline content: @Composable () -> Unit,
+    context: Context
+) = apply {
+    setContent {
+        content()
+        LaunchedEffect(controller, onCaptured) {
+            controller.captureRequests
+                .mapNotNull { config -> drawToBitmapPostLaidOut(context, config) }
+                .onEach { bitmap -> onCaptured(bitmap.asImageBitmap(), null) }
+                .catch { error -> onCaptured(null, error) }
+                .launchIn(this)
+        }
+    }
+}
+
+/**
+ * Waits till this [View] is laid off and then draws it to the [Bitmap] with specified [config].
+ */
+private suspend fun View.drawToBitmapPostLaidOut(context: Context, config: Bitmap.Config): Bitmap {
+    return suspendCoroutine { continuation ->
+        doOnLayout { view ->
+            try {
+                // Initially, try to capture bitmap using drawToBitmap extension function
+                continuation.resume(view.drawToBitmap(config))
+            } catch (e: IllegalArgumentException) {
+                // For device with API version O(26) and above should draw Bitmap using PixelCopy
+                // API. The reason behind this is it throws IllegalArgumentException saying
+                // "Software rendering doesn't support hardware bitmaps"
+                // See this issue for the reference:
+                // https://github.com/PatilShreyas/Capturable/issues/7
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    val window = context.findActivity().window
+
+                    drawBitmapWithPixelCopy(
+                        view = view,
+                        window = window,
+                        config = config,
+                        onDrawn = { bitmap -> continuation.resume(bitmap) },
+                        onError = { error -> continuation.resumeWithException(error) }
+                    )
+                } else {
+                    continuation.resumeWithException(e)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Draws a [view] to a [Bitmap] with [config] using a [PixelCopy] API.
+ * Gives callback [onDrawn] after successfully drawing Bitmap otherwise invokes [onError].
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+private fun drawBitmapWithPixelCopy(
+    view: View,
+    window: Window,
+    config: Bitmap.Config,
+    onDrawn: (Bitmap) -> Unit,
+    onError: (Throwable) -> Unit
+) {
+    val width = view.width
+    val height = view.height
+
+    val bitmap = Bitmap.createBitmap(width, height, config)
+
+    val (x, y) = IntArray(2).apply { view.getLocationInWindow(this) }
+    val rect = Rect(x, y, x + width, y + height)
+
+    PixelCopy.request(
+        window,
+        rect,
+        bitmap,
+        { copyResult ->
+            if (copyResult == PixelCopy.SUCCESS) {
+                onDrawn(bitmap)
+            } else {
+                onError(RuntimeException("Failed to draw bitmap"))
+            }
+        },
+        Handler(Looper.getMainLooper())
+    )
+}
+
+/**
+ * Traverses through this [Context] and finds [Activity] wrapped inside it.
+ */
+internal fun Context.findActivity(): Activity {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    throw IllegalStateException("Unable to retrieve Activity from the current context")
+}

--- a/app/src/main/java/com/busymodernpeople/galapagos/ui/component/capture/CaptureController.kt
+++ b/app/src/main/java/com/busymodernpeople/galapagos/ui/component/capture/CaptureController.kt
@@ -1,0 +1,22 @@
+package com.busymodernpeople.galapagos.ui.component.capture
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class CaptureController internal constructor() {
+
+    private val _captureRequests = MutableSharedFlow<Bitmap.Config>(replay = 1)
+    internal val captureRequests = _captureRequests.asSharedFlow()
+
+    fun capture() {
+        _captureRequests.tryEmit(Bitmap.Config.ARGB_8888)
+    }
+}
+
+@Composable
+fun rememberCaptureController(): CaptureController {
+    return remember { CaptureController() }
+}


### PR DESCRIPTION
기존 하얀색의 불투명도를 조절해서 배경을 반투명으로 한 것과 다르게 배경을 실시간으로 캡쳐하고 블러처리했습니다.
Capturable, CaptureController를 이용해 컴포즈 뷰를 감싸서 캡쳐할 수 있습니다.
Glassmorphic Tab의 배걍을 실시간으로 캡쳐하고 블러처리 했습니다.